### PR TITLE
Add 3D NYC Map

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import type { Schema } from "../amplify/data/resource";
 import { generateClient } from "aws-amplify/data";
 import { useAuthenticator } from '@aws-amplify/ui-react';
-import {APIProvider, Map} from '@vis.gl/react-google-maps';
+import NYCMap from './NYCMap';
 
 const client = generateClient<Schema>();
 
@@ -41,18 +41,7 @@ function App() {
       </ul>
       <button onClick={signOut}>SignOut</button>
     </main>
-    <APIProvider apiKey={'AIzaSyDUCsGRdMUGdOzUfYyZk-OIvzMGLjOzBvY'}>
-      <Map
-        style={{width: '100vw', height: '100vh'}}
-        defaultCenter={{lat: 22.54992, lng: 0}}
-        defaultZoom={3}
-        gestureHandling={'greedy'}
-        disableDefaultUI={true}
-        mapTypeId="satellite"
-        tilt={67}
-        heading={45}
-      />
-    </APIProvider>
+    <NYCMap />
   </>
   );
 }

--- a/src/NYCMap.tsx
+++ b/src/NYCMap.tsx
@@ -1,0 +1,46 @@
+import {APIProvider, Map, InfoWindow} from '@vis.gl/react-google-maps';
+import {useState} from 'react';
+
+interface ClickInfo {
+  position: google.maps.LatLng;
+  placeId: string;
+}
+
+export default function NYCMap() {
+  const [info, setInfo] = useState<ClickInfo | null>(null);
+
+  const handleClick = (e: google.maps.MapMouseEvent) => {
+    if (!e.latLng) return;
+    const placeId = e.placeId;
+    if (placeId) {
+      e.stop();
+    }
+    setInfo({ position: e.latLng, placeId: placeId ?? '' });
+  };
+
+  return (
+    <APIProvider apiKey={'AIzaSyDUCsGRdMUGdOzUfYyZk-OIvzMGLjOzBvY'}>
+      <Map
+        style={{ width: '100vw', height: '100vh' }}
+        defaultCenter={{ lat: 40.7128, lng: -74.006 }}
+        defaultZoom={18}
+        gestureHandling={'greedy'}
+        disableDefaultUI={true}
+        mapTypeId="satellite"
+        tilt={67}
+        onClick={handleClick}
+      >
+        {info && (
+          <InfoWindow
+            position={info.position}
+            onCloseClick={() => setInfo(null)}
+          >
+            <div>
+              <b>Place ID:</b> {info.placeId || 'N/A'}
+            </div>
+          </InfoWindow>
+        )}
+      </Map>
+    </APIProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- add `NYCMap` component for 3D New York view
- show building placeId on click
- use `NYCMap` from `App`

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run build` *(fails: cannot find modules due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_685d78e4bda0832b8422da1a16ed727b